### PR TITLE
Using https instead of ssh to add vcpkg as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "cmake/external/re2"]
 	path = cmake/external/re2
 	url = https://github.com/google/re2.git
+[submodule "cmake/external/vcpkg"]
+	path = cmake/external/vcpkg
+	url = https://github.com/Microsoft/vcpkg.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,3 @@
 [submodule "cmake/external/re2"]
 	path = cmake/external/re2
 	url = https://github.com/google/re2.git
-[submodule "cmake/external/vcpkg"]
-	path = cmake/external/vcpkg
-	url = git@github.com:Microsoft/vcpkg.git


### PR DESCRIPTION
Using https instead of ssh to add vcpkg as submodule