### PR TITLE
Enable logging and proper initialize the session

### DIFF
--- a/cmake/onnxruntime_hosting.cmake
+++ b/cmake/onnxruntime_hosting.cmake
@@ -38,6 +38,7 @@ endif()
 
 file(GLOB_RECURSE onnxruntime_hosting_srcs
   "${ONNXRUNTIME_ROOT}/hosting/main.cc"
+  "${ONNXRUNTIME_ROOT}/hosting/environment.cc"
 )
 
 # For IDE only
@@ -45,7 +46,7 @@ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_hosting_srcs} ${onnxruntime_h
 
 # Hosting library
 add_library(onnxruntime_hosting_lib ${onnxruntime_hosting_lib_srcs})
-target_include_directories(hosting_proto PRIVATE
+target_include_directories(onnxruntime_hosting_lib PRIVATE
   ${ONNXRUNTIME_ROOT}
   ${CMAKE_CURRENT_BINARY_DIR}/onnx
   ${ONNXRUNTIME_ROOT}/hosting/http

--- a/onnxruntime/hosting/environment.cc
+++ b/onnxruntime/hosting/environment.cc
@@ -27,7 +27,7 @@ const onnxruntime::logging::Logger& HostingEnvironment::GetLogger() {
   return this->default_logging_manager_.DefaultLogger();
 }
 
-const std::shared_ptr<onnxruntime::InferenceSession> HostingEnvironment::GetSession() {
+std::shared_ptr<onnxruntime::InferenceSession> HostingEnvironment::GetSession() const {
   return this->session_;
 }
 

--- a/onnxruntime/hosting/environment.cc
+++ b/onnxruntime/hosting/environment.cc
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <memory>
+#include "core/common/logging/logging.h"
+
+#include "environment.h"
+#include "log_sink.h"
+
+namespace onnxruntime {
+namespace hosting {
+
+HostingEnvironment::HostingEnvironment() : logger_id_("HostingLog"),
+                                           default_logging_manager_(
+                                               std::unique_ptr<onnxruntime::logging::ISink>{&sink_},
+                                               onnxruntime::logging::Severity::kVERBOSE,
+                                               /* default_filter_user_data */ false,
+                                               onnxruntime::logging::LoggingManager::InstanceType::Default,
+                                               &logger_id_) {
+  auto status = onnxruntime::Environment::Create(this->runtime_environment_);
+
+  // The session initialization MUST BE AFTER environment creation
+  session_ = std::make_shared<onnxruntime::InferenceSession>(options_, &default_logging_manager_);
+}
+
+const onnxruntime::logging::Logger& HostingEnvironment::GetLogger() {
+  return this->default_logging_manager_.DefaultLogger();
+}
+
+const std::shared_ptr<onnxruntime::InferenceSession> HostingEnvironment::GetSession() {
+  return this->session_;
+}
+
+}  // namespace hosting
+}  // namespace onnxruntime

--- a/onnxruntime/hosting/environment.h
+++ b/onnxruntime/hosting/environment.h
@@ -19,7 +19,7 @@ class HostingEnvironment {
   HostingEnvironment();
 
   const onnxruntime::logging::Logger& GetLogger();
-  const std::shared_ptr<onnxruntime::InferenceSession> GetSession();
+  std::shared_ptr<onnxruntime::InferenceSession> GetSession() const;
 
  private:
   std::string logger_id_;

--- a/onnxruntime/hosting/environment.h
+++ b/onnxruntime/hosting/environment.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef ONNXRUNTIME_HOSTING_ENVIRONMENT_H
+#define ONNXRUNTIME_HOSTING_ENVIRONMENT_H
+
+#include <memory>
+
+#include "core/framework/environment.h"
+#include "core/common/logging/logging.h"
+#include "core/session/inference_session.h"
+#include "log_sink.h"
+
+namespace onnxruntime {
+namespace hosting {
+
+class HostingEnvironment {
+ public:
+  HostingEnvironment();
+
+  const onnxruntime::logging::Logger& GetLogger();
+  const std::shared_ptr<onnxruntime::InferenceSession> GetSession();
+
+ private:
+  std::string logger_id_;
+  onnxruntime::hosting::LogSink sink_;
+  std::unique_ptr<onnxruntime::Environment> runtime_environment_;
+  onnxruntime::logging::LoggingManager default_logging_manager_;
+  onnxruntime::SessionOptions options_;
+  std::shared_ptr<onnxruntime::InferenceSession> session_;
+};
+
+}  // namespace hosting
+}  // namespace onnxruntime
+
+#endif  //ONNXRUNTIME_HOSTING_ENVIRONMENT_H

--- a/onnxruntime/hosting/log_sink.h
+++ b/onnxruntime/hosting/log_sink.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef ONNXRUNTIME_HOSTING_LOG_SINK_H
+#define ONNXRUNTIME_HOSTING_LOG_SINK_H
+
+#include <iostream>
+#include "core/common/logging/logging.h"
+#include "core/common/logging/sinks/ostream_sink.h"
+
+namespace onnxruntime {
+namespace hosting {
+
+class LogSink : public onnxruntime::logging::OStreamSink {
+ public:
+  LogSink() : OStreamSink(std::cout, /*flush*/ true) {
+  }
+};
+}  // namespace hosting
+}  // namespace onnxruntime
+#endif  //ONNXRUNTIME_HOSTING_LOG_SINK_H

--- a/onnxruntime/hosting/main.cc
+++ b/onnxruntime/hosting/main.cc
@@ -4,7 +4,7 @@
 #include "boost/program_options.hpp"
 
 #include "http_server.h"
-#include "core/session/inference_session.h"
+#include "environment.h"
 
 namespace po = boost::program_options;
 namespace beast = boost::beast;
@@ -61,8 +61,15 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  onnxruntime::SessionOptions options{};
-  onnxruntime::InferenceSession session(options);
+  onnxruntime::hosting::HostingEnvironment env;
+  auto logger = env.GetLogger();
+
+  // TODO: below code snippet just trying to show case how to use the "env".
+  //       Will be moved to proper place.
+  LOGS(logger, VERBOSE) << "Logging manager initialized.";
+  LOGS(logger, VERBOSE) << "Model path: " << vm["model_path"].as<std::string>();
+  auto status = env.GetSession()->Load(vm["model_path"].as<std::string>());
+  LOGS(logger, VERBOSE) << "Load Model Status: " << status.Code() << " ---- Error: [" << status.ErrorMessage() << "]";
 
   auto const boost_address = boost::asio::ip::make_address(vm["address"].as<std::string>());
 


### PR DESCRIPTION
Sample of logging:

```
/home/klein/code/onnxruntime/cmake/build/CLion/onnxruntime_hosting -a 0.0.0.0 -p 8901 -t 10 -m /home/klein/code/onnx/models/mnist/mnist/model.onnx
2019-03-14 10:14:36.430724047 [V:onnxruntime:HostingLog, main.cc:66 main] Logging manager initialized.
2019-03-14 10:14:36.430768484 [V:onnxruntime:HostingLog, main.cc:67 main] Model path: /home/klein/code/onnx/models/mnist/mnist/model.onnx
2019-03-14 10:14:36.432149181 [V:onnxruntime:HostingLog, main.cc:69 main] Load Model Status: 0 ---- Error: []
Listening at: 
 
    http://0.0.0.0:8901
```