### PR TITLE
Install g++-7 for vcpkg build

### DIFF
--- a/tools/ci_build/github/linux/ubuntu16.04/install.sh
+++ b/tools/ci_build/github/linux/ubuntu16.04/install.sh
@@ -27,7 +27,11 @@ apt-get update && apt-get install -y --no-install-recommends \
         bzip2 \
         unzip \
         rsync libunwind8 \
-        python3-setuptools python3-numpy python3-wheel python python3-pip
+        python3-setuptools python3-numpy python3-wheel python python3-pip \
+        software-properties-common
+
+add-apt-repository ppa:ubuntu-toolchain-r/test
+apt-get update && apt-get install -y --no-install-recommends g++-7
 
 locale-gen en_US.UTF-8
 update-locale LANG=en_US.UTF-8


### PR DESCRIPTION
This will not impact ONNX runtime build. 

```
onnxruntimedev@b21e5600308a:~$ gcc --version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

onnxruntimedev@b21e5600308a:~$ g++ --version
g++ (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

onnxruntimedev@b21e5600308a:~$ cc --version
cc (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

onnxruntimedev@b21e5600308a:~$ c++ --version
c++ (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

onnxruntimedev@b21e5600308a:~$ g++-7 --version
g++-7 (Ubuntu 7.4.0-1ubuntu1~16.04~ppa1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

onnxruntimedev@b21e5600308a:~$ gcc-7 --version
gcc-7 (Ubuntu 7.4.0-1ubuntu1~16.04~ppa1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```